### PR TITLE
FHIRPath stored procedures in User.SQLvar + some cosmetic changes to iris.script

### DIFF
--- a/iris.script
+++ b/iris.script
@@ -5,7 +5,7 @@ zn "HSLIB"
 set namespace="FHIRSERVER"
 Set appKey = "/fhir/r4"
 Set strategyClass = "HS.FHIRServer.Storage.Json.InteractionsStrategy"
-Set metadataConfigKey = "HL7v40"
+set metadataPackages = $lb("hl7.fhir.r4.core@4.0.1")
 set importdir="/opt/irisapp/src"
 
 //Install a Foundation namespace and change to it
@@ -16,14 +16,15 @@ zn namespace
 Do ##class(HS.FHIRServer.Installer).InstallNamespace()
 
 // Install an instance of a FHIR Service into the current namespace
-Do ##class(HS.FHIRServer.Installer).InstallInstance(appKey, strategyClass, metadataConfigKey,"",0)
+Do ##class(HS.FHIRServer.Installer).InstallInstance(appKey, strategyClass, metadataPackages)
 
+// Configure FHIR Service instance to accept unauthenticated requests
 set strategy = ##class(HS.FHIRServer.API.InteractionsStrategy).GetStrategyForEndpoint(appKey)
 set config = strategy.GetServiceConfigData()
 set config.DebugMode = 4
 do strategy.SaveServiceConfigData(config)
 
-zw ##class(HS.FHIRServer.Tools.DataLoader).SubmitResourceFiles("/opt/irisapp/fhirdata/", namespace, appKey)
+zw ##class(HS.FHIRServer.Tools.DataLoader).SubmitResourceFiles("/opt/irisapp/fhirdata/", "FHIRServer", appKey)
 
 do $System.OBJ.LoadDir("/opt/irisapp/src","ck",,1)
 zpm "install fhir-portal"

--- a/src/User/SQLvar.cls
+++ b/src/User/SQLvar.cls
@@ -39,4 +39,44 @@ ClassMethod GetAtJSON(json As %String, position As %Integer) As %String(MAXLEN="
     Quit $s(result'="":$s(($classname(result)="%Library.DynamicObject")||($classname(result)="%Library.DynamicArray"):result.%ToJSON(),1:{}.%Set(key,result,dyna.%GetTypeOf(key)).%ToJSON()),1:"")
 }
 
+/// Return JSON array resulting from FHIRPath query
+ClassMethod GetFHIRPath(json As %String, path As %String, mdSetKey As %String = "HL7v40") As %String(MAXLEN="") [ SqlName = GetFHIRPath, SqlProc ]
+{
+	if (json = "") quit ""
+	
+	#dim fpAPI As HS.FHIRPath.API = ##class(HS.FHIRPath.API).getInstance(mdSetKey)
+	#dim node As HS.FHIRPath.Node = fpAPI.parse(path)
+
+	#dim array As %DynamicArray = fpAPI.evaluateToJson({}.%FromJSON(json), node)
+	//#dim array As %DynamicArray = $$%EvaluatePath^%DocDB.Document(json, path)
+	if (array = "") quit ""
+
+	quit array.%ToJSON()
 }
+
+/// Return just one result, either JSON object/array or a single value. 
+/// resourceType argument is used to distinguish arrays from non-arrays.
+ClassMethod GetFHIRPathOne(json As %String, path As %String, resourceType As %String, mdSetKey As %String = "HL7v40") As %String(MAXLEN="") [ SqlName = GetFHIRPathOne, SqlProc ]
+{
+	if (json = "") quit ""
+	
+	#dim fpAPI As HS.FHIRPath.API = ##class(HS.FHIRPath.API).getInstance(mdSetKey)
+	#dim node As HS.FHIRPath.Node = fpAPI.parse(path)
+
+	#dim array As %DynamicArray = fpAPI.evaluateToJson({}.%FromJSON(json), node)
+	//#dim array As %DynamicArray = $$%EvaluatePath^%DocDB.Document(json, path)
+	if (array = "") quit ""
+
+	do fpAPI.getPathAndType(resourceType, node, .contextPath, .fhirType)
+	
+	#dim result = array
+	if (($get(fhirType("ar")) = $$$NO) || ($extract($zstrip(path, ">W"), *) = "]"))
+	{
+		set result = array.%Get(0)
+	}
+	
+	quit $case($isObject(result), $$$YES:/*result.%ClassName(1) _ ":" _ */result.%ToJSON(), :result)
+}
+
+}
+


### PR DESCRIPTION
## What?
1. I've added two "SqlProc" methods to User.SQLvar: GetFHIRPath() and  GetFHIRPathOne().
2. I've slightly modified iris.script file to align with the current version of InterSystems IRIS for Health. 

## Testing new stored procedures
SELECT 
GetFHIRPath(r.ResourceString, 'identifier'),
GetFHIRPathOne(r.ResourceString, 'identifier[2].system', r.ResourceType),
GetFHIRPathOne(r.ResourceString, 'identifier[2].value', r.ResourceType), 
GetFHIRPath(r.ResourceString, 'name'),
GetFHIRPath(r.ResourceString, 'name.given'),
GetFHIRPathOne(r.ResourceString, 'name[0].given[0]', r.ResourceType) 
FROM HSFHIR_X0001_R.Rsrc r 
  JOIN HSFHIR_X0001_S.Patient p ON p._id = r.id
WHERE FOR SOME %ELEMENT(p.identifier) (%VALUE='999-16-6498')