### PR TITLE
--check-caps false

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     restart: always
-    command: --check-caps false
+#   command: --check-caps false
     ports: 
       - 32782:1972
       - 32783:52773
@@ -13,3 +13,4 @@ services:
     command: 
       - -a
       - iris session iris -U%SYS '##class(Security.Users).UnExpireUserPasswords("*")'
+      - --check-caps false


### PR DESCRIPTION
only 1 tag command is allowed.  2nd overwrites 1st

 [ERROR] Required Linux capability cap_setuid is missing.
 [ERROR] Required Linux capability cap_dac_override is missing.
 [ERROR] Required Linux capability cap_fowner is missing.
 [ERROR] Required Linux capability cap_setgid is missing.