### PR TITLE
enhance: specify health as system requirement

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -7,6 +7,7 @@
       <Description>InterSystems FHIR Server with a demo frontend</Description>
       <Keywords>FHIR,Server</Keywords>
       <Packaging>module</Packaging>
+      <SystemRequirements Interoperability="enabled" Health="true"/>
     <Default Name="name" Value="FHIRSERVER" />
     <Default Name="Webapp" Value="/fhir/r4" />
     <Default Name="AddTestData" Value="1" />


### PR DESCRIPTION
Hi there, 

InterSystems is rolling out a [newer version](https://github.com/intersystems/ipm/tree/v1) of package manager that allows package contributors to declare their package requires healthcare/healthconnect/iris for health. With this change, a user will get a descriptive warning:
```
ERROR! The module requires InterSystems IRIS for Health, HealthConnect, or HealthShare. Current system is not compatible.
```
when trying to install the package on incompatible systems with the new package manager.

This change is also backward compatible.