### PR TITLE
Allow JsonAdvSql configuration to be made during ZPM install

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -11,12 +11,14 @@
     <Default Name="name" Value="FHIRSERVER" />
     <Default Name="Webapp" Value="/fhir/r4" />
     <Default Name="AddTestData" Value="1" />
+    <Default Name="InteractionsStrategy" Value="Json" />
     <SourcesRoot>src</SourcesRoot>
     <Invokes>
     <Invoke Class="fhirtemplate.Setup" Method="SetupFHIRServer" Phase="Activate" When="After" >
       <Arg>${name}</Arg>
       <Arg>${Webapp}</Arg>
       <Arg>${AddTestData}</Arg>
+      <Arg>${InteractionsStrategy}</Arg>
      </Invoke>
     </Invokes>
     <Resource Name="fhirtemplate.PKG"/>
@@ -36,7 +38,8 @@
 &#13;Name - to alter created/modified namespace (now/default FHIRSERVER)
 &#13;AddTestData - import some test data to the FHIR server, otherwise don't
 &#13;Webapp - provide the name for the web application to expose R4 API. /fhir/r4 is by default
-&#13;USER>zpm "install fhir-server -Dzpm.name=ALTERFHIRSERVER -Dzpm.Webapp=/fhir/r7 -Dzpm.AddTestData=0"
+&#13;InteractionsStrategy - defines the FHIR Search and Operations available. JsonAdvSql is the latest and greatest in IRIS for Health 2023.3 and later.
+&#13;USER>zpm "install fhir-server -Dzpm.name=ALTERFHIRSERVER -Dzpm.InteractionsStrategy=JsonAdvSql -Dzpm.Webapp=/fhir/r7 -Dzpm.AddTestData=0"
 </AfterInstallMessage>
   </Module>
  </Document>

--- a/module.xml
+++ b/module.xml
@@ -38,7 +38,7 @@
 &#13;Name - to alter created/modified namespace (now/default FHIRSERVER)
 &#13;AddTestData - import some test data to the FHIR server, otherwise don't
 &#13;Webapp - provide the name for the web application to expose R4 API. /fhir/r4 is by default
-&#13;InteractionsStrategy - defines the FHIR Search and Operations available. JsonAdvSql is the latest and greatest in IRIS for Health 2023.3 and later.
+&#13;InteractionsStrategy - defines the FHIR Search and Operations available. JsonAdvSql is more performant and offers more search parameters, operations, and OAuth scope support.
 &#13;USER>zpm "install fhir-server -Dzpm.name=ALTERFHIRSERVER -Dzpm.InteractionsStrategy=JsonAdvSql -Dzpm.Webapp=/fhir/r7 -Dzpm.AddTestData=0"
 </AfterInstallMessage>
   </Module>

--- a/src/FHIR/utils.cls
+++ b/src/FHIR/utils.cls
@@ -1,13 +1,17 @@
 Class FHIR.utils
 {
 
-ClassMethod install(NAMESPACE As %String = "FHIRDEMO") As %Status
+ClassMethod install(NAMESPACE As %String = "FHIRDEMO", interactionsStrategy As %String(VALUELIST=",Json,JsonAdvSql") = "Json") As %Status
 {
     set sc = $$$OK
     set ns = $NAMESPACE
     zn "HSLIB"
     Set appKey = "/"_$zcvt(NAMESPACE,"l")_"/fhir/r4"
-    Set strategyClass = "HS.FHIRServer.Storage.Json.InteractionsStrategy"
+    if interactionsStrategy = "Json" {
+        set strategyClass = "HS.FHIRServer.Storage.Json.InteractionsStrategy"
+    } elseif interactionsStrategy = "JsonAdvSql" {
+        set strategyClass = "HS.FHIRServer.Storage.JsonAdvSQL.InteractionsStrategy"
+    }
     Set metadataConfigKey = "HL7v40"
 
     //Install a Foundation namespace and change to it

--- a/src/fhirtemplate/Setup.cls
+++ b/src/fhirtemplate/Setup.cls
@@ -1,14 +1,18 @@
 Class fhirtemplate.Setup
 {
 
-ClassMethod SetupFHIRServer(ns="FHIRSERVER",appKey="/fhir/r4",testLoad=1) As %Status
+ClassMethod SetupFHIRServer(ns = "FHIRSERVER", appKey = "/fhir/r4", testLoad = 1, interactionsStrategy As %String(VALUELIST=",Json,JsonAdvSql") = "Json") As %Status
 {
     set st=$$$OK
     Write !,"=== Initialization with parameters: Namespace: "_ns_", Webapp: "_appKey_", AddTestData: "_testLoad,!
     zn "HSLIB"
     set namespace=ns
     ;Set appKey = "/fhir/r4"
-    Set strategyClass = "HS.FHIRServer.Storage.Json.InteractionsStrategy"
+    if interactionsStrategy = "Json" {
+        set strategyClass = "HS.FHIRServer.Storage.Json.InteractionsStrategy"
+    } elseif interactionsStrategy = "JsonAdvSql" {
+        set strategyClass = "HS.FHIRServer.Storage.JsonAdvSQL.InteractionsStrategy"
+    }
     set metadataPackages = $lb("hl7.fhir.r4.core@4.0.1")
     Set metadataConfigKey = "HL7v40"
     ;set importdir="/opt/irisapp/src"
@@ -46,7 +50,7 @@ ClassMethod LoadPatientData(path, namespace, appKey) As %Status
     quit ##class(HS.FHIRServer.Tools.DataLoader).SubmitResourceFiles(path, namespace, appKey)
 }
 
-ClassMethod AddApp(ns={$namespace}) As %Status
+ClassMethod AddApp(ns = {$namespace}) As %Status
 {
     set namespace=ns
     zn "%SYS"


### PR DESCRIPTION
JsonAdvSql is more performant and offers more search parameters, FHIR operations, and richer OAuth support. This will allow ZPM users to install a JsonAdvSql FHIR Server on IRIS for Health 2024.1 or later using a flag:

`zpm "install fhir-server -D InteractionsStrategy=JsonAdvSql"`